### PR TITLE
Add realcundo to the waiting list

### DIFF
--- a/waitinglist.rst
+++ b/waitinglist.rst
@@ -11,3 +11,4 @@ based on the order of this list):
 * Eleni Lixourioti - London, UK. contact@eleni.co. Curiosity-driven developer, girls-in-tech supporter (and "all-people"-in tech supporter!), proficient in working with cats on the keyboard. Known as Geekfish(gh) or geekfish_(twitter)
 * Ewan Willis - Cambridge, UK. ewanwillis@gmail.com. ZX Spectrum initiated C++ developer who really likes python and making games. :
 * Rich Wareham - Cambridge, UK. rich.microbit@richwareham.com. BBC initiated C/C++/Python/JavaScript developer who's eager to fiddle with micropython.
+* Peter Cunderlik - Cambridge, UK. peter.cunderlik+microbit@gmail.com. Spectrum Basic to Pascal to C++ to Python dev. Can't wait to get some LEDs flash!


### PR DESCRIPTION
Had a chance to play with micro:bit last week at the Cambridge Python Group and one hour was not enough. All ideas (naturally) came to me only after I left the building.
