### PR TITLE
pyboard.py is actually working

### DIFF
--- a/microbit/mohandas.html
+++ b/microbit/mohandas.html
@@ -111,10 +111,9 @@
                         <a href="https://hub.docker.com/r/ncoghlan/microbit-dev/">ncoghlan/microbit-dev</a>.</p>
                         <p>That image includes a full yotta build environment together with Nicholas Tollervey's
                         <a href="https://github.com/ntoll/microrepl/">microrepl</a> project, making it straightforward both to
-                        use the micro:bit interactively, and to build new custom firmware images. There unfortunately appears to
-                        be a <a href="https://github.com/bbcmicrobit/micropython/issues/156">bug</a> with using the pyboard utility
-                        from within a Docker container, so it currently isn't possible to use that to upload and run scripts on
-                        the device directly from within the container.</p>
+                        use the micro:bit interactively, to build new custom firmware images and to experiment with image
+                        ideas by using `pyboard.py` to upload and run scripts on the device directly from within the
+                        container.</p>
                         <p>Together with other interruptions, getting a reliable build container together took longer than
                         I anticipated though, so I never got to starting on the second goal - instead, I'll include the
                         microphone along with Mark Schafer's 3D printed micro:bit diffuser in the package I pass along to


### PR DESCRIPTION
Damien pointed out that I had left out the device argument to pyboard.py

microrepl was working because it has the additional code to automatically
locate which serial device (if any) is the micro:bit.
